### PR TITLE
fix manifest merger error by removing label and supportrtl

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:name=".SampleApplication">
         <activity android:name=".SampleActivity">


### PR DESCRIPTION
https://android.jlelse.eu/2-lines-in-manifest-to-remove-when-sharing-your-android-library-565d4c4af04a